### PR TITLE
Changed logic for checking if amounts are positive

### DIFF
--- a/lib/soacsv2mt940/amount.rb
+++ b/lib/soacsv2mt940/amount.rb
@@ -21,7 +21,7 @@ module SOACSV2MT940
     ##
     # Returns the credit / debit indicator for the amount
     def credit_debit_indicator
-      if amount.positive?
+      if amount >= 0
         'C'
       else
         'D'

--- a/lib/soacsv2mt940/amount.rb
+++ b/lib/soacsv2mt940/amount.rb
@@ -21,7 +21,7 @@ module SOACSV2MT940
     ##
     # Returns the credit / debit indicator for the amount
     def credit_debit_indicator
-      if amount >= 0
+      if amount > 0
         'C'
       else
         'D'


### PR DESCRIPTION
positive? causes this error on my machine:

"undefined method `positive?'"

`>= 0` might not be particularly idiomatic Ruby code but it works regardless of the Ruby version.