### PR TITLE
Reverse SOA instead of sorting.

### DIFF
--- a/lib/soacsv2mt940/soacsv.rb
+++ b/lib/soacsv2mt940/soacsv.rb
@@ -74,7 +74,7 @@ module SOACSV2MT940
         retval
       end
 
-      csv_data.sort_by { |row| row[:buchungstag] }
+      csv_data.reverse_each
     end
   end
 end


### PR DESCRIPTION
Actually, the SOA _is_ sorted, but the wrong way around. Sorting
like before would sort by day-month-year which is obviously wrong
and causes wrong saldo.